### PR TITLE
Add v4 RPC query/mutation examples and refresh README usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,30 @@ npm install @tanstack/react-query effect
 
 # Initialize
 
-```ts
+```tsx
 // src/utils/effect-query.ts
+import { useQuery } from "@tanstack/react-query";
 import { createEffectQuery } from "effect-query";
-import { Layer } from "effect";
+import { Effect, Layer, ManagedRuntime, ServiceMap } from "effect";
 
-export const eq = createEffectQuery(Layer.empty);
+export class GreetingApi extends ServiceMap.Service<
+  GreetingApi,
+  {
+    readonly loadGreeting: () => Effect.Effect<string>;
+  }
+>()("example/GreetingApi") {}
+
+const GreetingApiLive = Layer.succeed(GreetingApi)({
+  loadGreeting: () => Effect.succeed("Hello, world!"),
+});
+
+export const eq = createEffectQuery(GreetingApiLive);
 
 // Alternative: Create from effect-query from ManagedRuntime instead of Layer
 import { createEffectQueryFromManagedRuntime } from "effect-query";
-import { Layer, ManagedRuntime } from "effect";
 
-const managedRuntime = ManagedRuntime.make(Layer.empty);
-export const eq = createEffectQueryFromManagedRuntime(managedRuntime);
+const runtime = ManagedRuntime.make(GreetingApiLive);
+export const eqFromRuntime = createEffectQueryFromManagedRuntime(runtime);
 ```
 
 # Query Example
@@ -47,14 +58,17 @@ export const eq = createEffectQueryFromManagedRuntime(managedRuntime);
 // src/pages/example.tsx
 import { useQuery } from "@tanstack/react-query";
 import { Effect } from "effect";
-import { eq } from "./effect-query";
+import { GreetingApi, eq } from "./effect-query";
 
-export const eq = createEffectQuery(Layer.empty);
 export default function HomeRoute() {
   const { data, status } = useQuery(
     eq.queryOptions({
       queryKey: ["namespace", "action"],
-      queryFn: () => Effect.succeed("Hello, world!"),
+      queryFn: () =>
+        Effect.gen(function* () {
+          const greetingApi = yield* GreetingApi;
+          return yield* greetingApi.loadGreeting();
+        }),
     })
   );
 
@@ -71,17 +85,48 @@ export default function HomeRoute() {
 
 ```tsx
 // src/pages/users.tsx
-import { eq } from "./effectQuery";
+import { createEffectQueryFromManagedRuntime } from "effect-query";
 import { useMutation } from "@tanstack/react-query";
+import {
+  Console,
+  Data,
+  Duration,
+  Effect,
+  Layer,
+  ManagedRuntime,
+  ServiceMap,
+} from "effect";
+
+class UserUpdateError extends Data.TaggedError("UserUpdateError")<{
+  message: string;
+}> {}
+
+class UserApi extends ServiceMap.Service<
+  UserApi,
+  {
+    readonly updateUser: (id: string) => Effect.Effect<string, UserUpdateError>;
+  }
+>()("example/UserApi") {}
+
+const UserApiLive = Layer.succeed(UserApi)({
+  updateUser: (id: string) =>
+    Effect.gen(function* () {
+      yield* Effect.sleep(Duration.millis(1000));
+      yield* Console.log(`Updating user ${id}...`);
+      return "User updated";
+    }),
+});
+
+const runtime = ManagedRuntime.make(UserApiLive);
+export const eq = createEffectQueryFromManagedRuntime(runtime);
 
 // You can move this outside of the component and even share it with other components
 const updateUserOptions = eq.mutationOptions({
   mutationKey: ["updateUserOptions"],
-  mutationFn: () =>
+  mutationFn: (variables: { id: string }) =>
     Effect.gen(function* () {
-      const user = yield* Effect.sleep(1000);
-      yield* Console.log("Updating user...");
-      return Effect.succeed("User updated");
+      const userApi = yield* UserApi;
+      return yield* userApi.updateUser(variables.id);
     }),
 });
 
@@ -96,7 +141,7 @@ function UpdateUserPage({ id }: { id: string }) {
 When your Effect fails, the error object includes a `match` function that lets you handle different error types in a type-safe manner. When using match, the `OrElse` case is used as a catch-all for all the remaining unhandled failures and for defects. We are not able to fully check if defects can occur and therefore `OrElse` is required.
 
 ```tsx
-function Examle() {
+function Example() {
   const { data, status, error } = useQuery({
     /** ... */
   });
@@ -136,26 +181,29 @@ export default function UpdateUserPage({ id }: { id: string }) {
 
 # Usage with Effect HttpApi
 
-```ts
+```tsx
 // src/utils/effect-query.ts
+import { useQuery } from "@tanstack/react-query";
 import { createEffectQuery } from "effect-query";
-import { Layer } from "effect";
-import { HttpApiClient } from "@effect/platform";
+import { Effect, Layer, ServiceMap } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { HttpApiClient } from "effect/unstable/httpapi";
 import { HttpApiSpec } from "./http-api-spec";
 
 // Create your ApiClient service
-export class ApiClient extends Effect.Service<ApiClient>()(
-  "example/ApiClient",
-  {
-    dependencies: [FetchHttpClient.layer],
-    effect: HttpApiClient.make(HttpApiSpec, {
-      baseUrl: "https://api.example.com",
-    }),
-  }
-) {}
+export class ApiClient extends ServiceMap.Service<
+  ApiClient,
+  HttpApiClient.ForApi<typeof HttpApiSpec>
+>()("example/ApiClient", {
+  make: HttpApiClient.make(HttpApiSpec, {
+    baseUrl: "https://api.example.com",
+  }),
+}) {}
 
 // Create a final layer for your Effect Query
-export const LiveLayer = Layer.mergeAll(ApiClient.Default);
+export const LiveLayer = Layer.effect(ApiClient)(ApiClient.make).pipe(
+  Layer.provide(FetchHttpClient.layer)
+);
 
 export const eq = createEffectQuery(LiveLayer);
 
@@ -178,12 +226,14 @@ export default function HomeRoute() {
 
 # Usage with Effect RPC
 
-```ts
+```tsx
 // src/utils/effect-query.ts
+import { useQuery } from "@tanstack/react-query";
 import { createEffectQuery } from "effect-query";
-import { Layer } from "effect";
-import { FetchHttpClient } from "@effect/platform";
-import { RpcClient, RpcSerialization } from "@effect/rpc";
+import { Effect, Layer, ServiceMap } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
+import { RpcGroups } from "./rpc-schema";
 
 const API_DOMAIN = "https://api.example.com";
 
@@ -191,26 +241,22 @@ const API_DOMAIN = "https://api.example.com";
 export const RpcProtocolLive = RpcClient.layerProtocolHttp({
   url: `${API_DOMAIN}/rpc`,
 }).pipe(
-  Layer.provide([
-    // use fetch for http requests
-    FetchHttpClient.layer
-    // use ndjson for serialization
-    RpcSerialization.layerNdjson,
-  ])
+  Layer.provideMerge(
+    Layer.mergeAll(FetchHttpClient.layer, RpcSerialization.layerNdjson)
+  )
 );
 
 // Create your ApiClient service
-export class MyRpcClient extends Effect.Service<MyRpcClient>()(
-  'example/MyRpcClient',
+export class MyRpcClient extends ServiceMap.Service<MyRpcClient>()(
+  "example/MyRpcClient",
   {
-    dependencies: [],
-    scoped: RpcClient.make(RpcGroups)
+    make: RpcClient.make(RpcGroups),
   }
 ) {}
 
 // Create a final layer for your Effect Query
-export const LiveLayer = MyRpcClient.Default.pipe(
-  Layer.provideMerge(RpcProtocolLive)
+export const LiveLayer = Layer.effect(MyRpcClient)(MyRpcClient.make).pipe(
+  Layer.provide(RpcProtocolLive)
 );
 
 export const eq = createEffectQuery(LiveLayer);
@@ -222,9 +268,46 @@ export default function HomeRoute() {
       queryKey: ["example", "hello-world"],
       queryFn: () => Effect.gen(function* () {
         const rpcClient = yield* MyRpcClient;
-        return yield* rpcClient.HelloWorld()
+        return yield* rpcClient.HelloWorld();
       }),
     })
+  );
+}
+```
+
+# Mutation with Effect RPC
+
+```tsx
+// src/pages/users.tsx
+import { useMutation } from "@tanstack/react-query";
+import { Cause, Effect } from "effect";
+import { MyRpcClient, eq } from "./effect-query";
+
+export default function UpdateUserPage() {
+  const { mutate } = useMutation(
+    eq.mutationOptions({
+      mutationKey: ["example", "rename-user"],
+      mutationFn: (variables: { id: string; name: string }) =>
+        Effect.gen(function* () {
+          const rpcClient = yield* MyRpcClient;
+          return yield* rpcClient.RenameUser(variables);
+        }),
+      onError: (error) =>
+        error.match({
+          RenameUserError: (renameUserError) => {
+            alert(renameUserError.message);
+          },
+          OrElse: (cause) => {
+            alert(`Error updating user: ${Cause.pretty(cause)}`);
+          },
+        }),
+    })
+  );
+
+  return (
+    <button onClick={() => mutate({ id: "user-123", name: "Ripley" })}>
+      Rename User
+    </button>
   );
 }
 ```

--- a/examples/react-example/app/lib/effect-rpc-example.ts
+++ b/examples/react-example/app/lib/effect-rpc-example.ts
@@ -1,0 +1,63 @@
+import { Console, Duration, Effect, Layer, Schema, ServiceMap } from "effect";
+import { Rpc, type RpcClient, RpcGroup, RpcTest } from "effect/unstable/rpc";
+import { createEffectQuery } from "effect-query";
+
+const greetingDelay = Duration.millis(250);
+const renameDelay = Duration.seconds(1);
+
+class RenameUserError extends Schema.TaggedErrorClass<RenameUserError>()(
+  "RenameUserError",
+  {
+    message: Schema.String,
+  }
+) {}
+
+const GetGreeting = Rpc.make("GetGreeting", {
+  payload: {
+    name: Schema.String,
+  },
+  success: Schema.String,
+});
+
+const RenameUser = Rpc.make("RenameUser", {
+  payload: {
+    id: Schema.String,
+    name: Schema.String,
+  },
+  success: Schema.String,
+  error: RenameUserError,
+});
+
+const ExampleRpcGroup = RpcGroup.make(GetGreeting, RenameUser);
+
+const ExampleRpcHandlersLive = ExampleRpcGroup.toLayer({
+  GetGreeting: ({ name }) =>
+    Effect.gen(function* () {
+      yield* Effect.sleep(greetingDelay);
+      return `Hello, ${name}, from Effect RPC!`;
+    }),
+  RenameUser: ({ id, name }) =>
+    Effect.gen(function* () {
+      yield* Effect.sleep(renameDelay);
+      yield* Console.log(`Renaming ${id} to ${name}...`);
+      if (name === "HAL") {
+        return yield* Effect.fail(
+          new RenameUserError({ message: "HAL is already reserved." })
+        );
+      }
+      return `Updated ${id} to ${name}`;
+    }),
+});
+
+export class ExampleRpcClient extends ServiceMap.Service<
+  ExampleRpcClient,
+  RpcClient.FromGroup<typeof ExampleRpcGroup>
+>()("example/ExampleRpcClient", {
+  make: RpcTest.makeClient(ExampleRpcGroup),
+}) {}
+
+export const ExampleRpcClientLive = Layer.effect(ExampleRpcClient)(
+  ExampleRpcClient.make
+).pipe(Layer.provide(ExampleRpcHandlersLive));
+
+export const rpcEq = createEffectQuery(ExampleRpcClientLive);

--- a/examples/react-example/app/routes.ts
+++ b/examples/react-example/app/routes.ts
@@ -14,6 +14,10 @@ export default [
         route("base-query", "routes/examples/base/base-query.tsx"),
         route("base-mutation", "routes/examples/base/base-mutation.tsx"),
       ]),
+      ...prefix("rpc", [
+        route("rpc-query", "routes/examples/rpc/rpc-query.tsx"),
+        route("rpc-mutation", "routes/examples/rpc/rpc-mutation.tsx"),
+      ]),
     ]),
   ]),
 ] satisfies RouteConfig;

--- a/examples/react-example/app/routes/examples/base/base-mutation.tsx
+++ b/examples/react-example/app/routes/examples/base/base-mutation.tsx
@@ -10,33 +10,50 @@ import {
   Effect,
   Layer,
   ManagedRuntime,
+  ServiceMap,
 } from "effect";
 import { createEffectQueryFromManagedRuntime } from "effect-query";
-
-export const managedRuntime = ManagedRuntime.make(Layer.empty);
-export const eq = createEffectQueryFromManagedRuntime(managedRuntime);
 
 class UserUpdateError extends Data.TaggedError("UserUpdateError")<{
   message: string;
 }> {}
 
-// You can move this outside of the component and even share it with other components
-const updateUserOptions = eq.mutationOptions({
-  mutationFn: (variables: { id: string }) =>
+class UserApi extends ServiceMap.Service<
+  UserApi,
+  {
+    readonly updateUser: (id: string) => Effect.Effect<string, UserUpdateError>;
+  }
+>()("example/UserApi") {}
+
+const UserApiLive = Layer.succeed(UserApi)({
+  updateUser: (id: string) =>
     Effect.gen(function* () {
       yield* Effect.sleep(Duration.millis(1000));
-      yield* Console.log(`Updating user ${variables.id}...`);
+      yield* Console.log(`Updating user ${id}...`);
       if (Math.random() < 0.5) {
         return yield* Effect.fail(
           new UserUpdateError({ message: "Failed to update user" })
         );
       }
       yield* Console.log("Updating user...");
-      return Effect.succeed("User updated");
+      return "User updated";
     }),
 });
 
-export default function UpdateUserPage({ id }: { id: string }) {
+export const managedRuntime = ManagedRuntime.make(UserApiLive);
+export const eq = createEffectQueryFromManagedRuntime(managedRuntime);
+
+// You can move this outside of the component and even share it with other components
+const updateUserOptions = eq.mutationOptions({
+  mutationFn: (variables: { id: string }) =>
+    Effect.gen(function* () {
+      const userApi = yield* UserApi;
+      return yield* userApi.updateUser(variables.id);
+    }),
+});
+
+export default function UpdateUserPage() {
+  const id = "user-123";
   const { mutate } = useMutation({
     ...updateUserOptions,
     onError: (error) =>
@@ -54,15 +71,18 @@ export default function UpdateUserPage({ id }: { id: string }) {
     },
   });
   return (
-    <button
-      onClick={() =>
-        mutate({
-          id,
-        })
-      }
-      type="button"
-    >
-      Update User
-    </button>
+    <div>
+      <p>Uses a `ManagedRuntime` built from a v4 `ServiceMap.Service`.</p>
+      <button
+        onClick={() =>
+          mutate({
+            id,
+          })
+        }
+        type="button"
+      >
+        Update User
+      </button>
+    </div>
   );
 }

--- a/examples/react-example/app/routes/examples/base/base-query.tsx
+++ b/examples/react-example/app/routes/examples/base/base-query.tsx
@@ -1,16 +1,24 @@
 /** biome-ignore-all lint/style/noMagicNumbers: dev example */
 /** biome-ignore-all lint/correctness/noNestedComponentDefinitions: not components */
 import { useQuery } from "@tanstack/react-query";
-import { Cause, Data, Effect, Layer } from "effect";
+import { Cause, Data, Effect, Layer, ServiceMap } from "effect";
 import { createEffectQuery } from "effect-query";
 
 class QueryError extends Data.TaggedError("QueryError")<{ hello: string }> {}
 class TestError extends Data.TaggedError("TestError")<{ message: string }> {}
-export const eq = createEffectQuery(Layer.empty);
 
-const queryOptions = eq.queryOptions({
-  queryKey: ["namespace"],
-  queryFn: () =>
+class GreetingApi extends ServiceMap.Service<
+  GreetingApi,
+  {
+    readonly loadGreeting: () => Effect.Effect<
+      string,
+      QueryError | TestError
+    >;
+  }
+>()("example/GreetingApi") {}
+
+const GreetingApiLive = Layer.succeed(GreetingApi)({
+  loadGreeting: () =>
     Effect.gen(function* () {
       if (Math.random() < 0.5) {
         return yield* Effect.fail(new QueryError({ hello: "world" }));
@@ -19,6 +27,17 @@ const queryOptions = eq.queryOptions({
         return yield* Effect.fail(new TestError({ message: "Test error" }));
       }
       return "Hello, world!";
+    }),
+});
+
+export const eq = createEffectQuery(GreetingApiLive);
+
+const queryOptions = eq.queryOptions({
+  queryKey: ["namespace"],
+  queryFn: () =>
+    Effect.gen(function* () {
+      const greetingApi = yield* GreetingApi;
+      return yield* greetingApi.loadGreeting();
     }),
 });
 
@@ -38,6 +57,7 @@ export default function HomeRoute() {
 
   return (
     <div>
+      <p>Uses a `ServiceMap.Service` provided through a v4 `Layer`.</p>
       {status === "pending" && <div>Loading...</div>}
       {status === "success" && <div>{data}</div>}
     </div>

--- a/examples/react-example/app/routes/examples/rpc/rpc-mutation.tsx
+++ b/examples/react-example/app/routes/examples/rpc/rpc-mutation.tsx
@@ -1,0 +1,58 @@
+/** biome-ignore-all lint/suspicious/noAlert: dev example */
+import { useMutation } from "@tanstack/react-query";
+import { Cause, Effect } from "effect";
+import { ExampleRpcClient, rpcEq } from "~/lib/effect-rpc-example";
+
+const renameUserOptions = rpcEq.mutationOptions({
+  mutationKey: ["rpc", "rename-user"],
+  mutationFn: (variables: { id: string; name: string }) =>
+    Effect.gen(function* () {
+      const rpcClient = yield* ExampleRpcClient;
+      return yield* rpcClient.RenameUser(variables);
+    }),
+});
+
+export default function RpcMutationRoute() {
+  const { data, mutate, status } = useMutation({
+    ...renameUserOptions,
+    onError: (error) =>
+      error.match({
+        RenameUserError: (renameUserError) => {
+          alert(renameUserError.message);
+        },
+        OrElse: (cause) => {
+          alert(`Error renaming user: ${Cause.pretty(cause)}`);
+        },
+      }),
+  });
+
+  return (
+    <div>
+      <p>Uses the same Effect RPC client inside a mutation.</p>
+      <button
+        onClick={() =>
+          mutate({
+            id: "user-123",
+            name: "Ripley",
+          })
+        }
+        type="button"
+      >
+        Rename to Ripley
+      </button>
+      <button
+        onClick={() =>
+          mutate({
+            id: "user-123",
+            name: "HAL",
+          })
+        }
+        type="button"
+      >
+        Rename to HAL
+      </button>
+      {status === "pending" && <div>Updating...</div>}
+      {status === "success" && data && <div>{data}</div>}
+    </div>
+  );
+}

--- a/examples/react-example/app/routes/examples/rpc/rpc-query.tsx
+++ b/examples/react-example/app/routes/examples/rpc/rpc-query.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { Effect } from "effect";
+import { ExampleRpcClient, rpcEq } from "~/lib/effect-rpc-example";
+
+const greetingName = "Voyager";
+
+const greetingQueryOptions = rpcEq.queryOptions({
+  queryKey: ["rpc", "get-greeting", greetingName],
+  queryFn: () =>
+    Effect.gen(function* () {
+      const rpcClient = yield* ExampleRpcClient;
+      return yield* rpcClient.GetGreeting({
+        name: greetingName,
+      });
+    }),
+});
+
+export default function RpcQueryRoute() {
+  const { data, status } = useQuery(greetingQueryOptions);
+
+  return (
+    <div>
+      <p>
+        Uses an Effect RPC client backed by a local `RpcGroup` through
+        `RpcTest.makeClient`.
+      </p>
+      {status === "pending" && <div>Loading...</div>}
+      {status === "success" && <div>{data}</div>}
+    </div>
+  );
+}

--- a/examples/react-example/app/routes/home.tsx
+++ b/examples/react-example/app/routes/home.tsx
@@ -12,6 +12,8 @@ export default function HomeRoute() {
     <div>
       <NavLink to="/examples/base/base-query"> Base Query</NavLink>
       <NavLink to="/examples/base/base-mutation"> Base Mutation</NavLink>
+      <NavLink to="/examples/rpc/rpc-query"> RPC Query</NavLink>
+      <NavLink to="/examples/rpc/rpc-mutation"> RPC Mutation</NavLink>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update README examples to align with Effect v4 patterns (`ServiceMap.Service`, `Layer.effect`, `ManagedRuntime`) across base, HttpApi, and RPC usage
- add a new local RPC example setup (`effect-rpc-example.ts`) with `RpcGroup`, `RpcTest.makeClient`, and typed success/error flows
- add new React example routes for RPC query and mutation, including typed error handling for `RenameUserError`
- refresh base query/mutation examples to use service-backed effects instead of inline `Layer.empty` effects
- wire new RPC example pages into route config and home navigation

## Testing
- Not run (no test commands provided in this change set)
- manual sanity check recommended: open the React example app and verify `/examples/rpc/rpc-query` shows greeting and `/examples/rpc/rpc-mutation` handles both success (`Ripley`) and error (`HAL`) paths